### PR TITLE
Заменил квантификатор * на +

### DIFF
--- a/patterns.json
+++ b/patterns.json
@@ -336,7 +336,7 @@
       "en": "Dollar amounts",
       "ru": "Долларовые суммы"
     },
-    "pattern": "\\$[0-9]*.[0-9][0-9]",
+    "pattern": "\\$[0-9]+.[0-9][0-9]",
     "placeholder": "$100 or $99.99",
     "description": {
       "en": "Dollar amounts, specified with a leading $ symbol.",


### PR DESCRIPTION
Регулярное выражение с квантификатором * пропускает любое количество
символов, в том числе и нулевое. Заменил его на +, чтобы до точки нужно 
было указать хотя бы символ 0. Вместо `$.99` теперь нужно  будет ввести `$0.99`